### PR TITLE
Hyper reduce math

### DIFF
--- a/source/hypergirgs/CMakeLists.txt
+++ b/source/hypergirgs/CMakeLists.txt
@@ -34,10 +34,14 @@ set(source_path  "${CMAKE_CURRENT_SOURCE_DIR}/source")
 
 set(headers
     ${include_path}/AngleHelper.h
+    ${include_path}/DistanceFilter.h
     ${include_path}/Hyperbolic.h
     ${include_path}/HyperbolicTree.h
     ${include_path}/HyperbolicTree.inl
+    ${include_path}/IntSort.h
+    ${include_path}/Point.h
     ${include_path}/RadiusLayer.h
+    ${include_path}/ScopedTimer.h
 )
 
 set(sources

--- a/source/hypergirgs/include/hypergirgs/AngleHelper.h
+++ b/source/hypergirgs/include/hypergirgs/AngleHelper.h
@@ -34,6 +34,8 @@ public:
 
     // returns a lower bound for the angular difference of two points in these cells
     static double dist(unsigned int cellA, unsigned int cellB, unsigned int level);
+
+    static int cellsBetween(unsigned int cellA, unsigned int cellB, unsigned int level);
 };
 
 

--- a/source/hypergirgs/include/hypergirgs/DistanceFilter.h
+++ b/source/hypergirgs/include/hypergirgs/DistanceFilter.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <array>
+#include <cmath>
+#include <limits>
+
+
+namespace hypergirgs {
+
+/**
+ * The filter should be used to compute bounds on the hyperbolic distance (or rather the cosh of it),
+ * such that vertices with this distance are guaranteed to be connected/disconnected.
+ *
+ * @tparam stages
+ *  The resolution of the filter (i.e. number of entries).
+ */
+template<size_t stages>
+class DistanceFilter {
+public:
+    /**
+     * Creates a distance filter for the hyperbolic connection probability.
+     *
+     * @param max_prob
+     *  If max_prob < 1.0, then queries to the filter are restricted to arguments in [0..max_prob).
+     *  This increases the resolution in the specified range.
+     * @param R
+     *  The radius of the hyperbolic disc.
+     * @param T
+     *  The temperature of the graph.
+     */
+    DistanceFilter(double max_prob, double R, double T)
+    : max_connection_prob(max_prob)
+    , stage_width(stages/max_prob)
+    {
+        for(int i=1; i < stages; i++)
+            filter_stages[i] = cosh(invConnectionProb(max_connection_prob / stages * i, R, T));
+        // TODO maybe we should not save these values
+        filter_stages[0] = std::numeric_limits<double>::infinity(); // at distance inf the conn prob is 0; cosh(inf)=inf
+        filter_stages[stages] = 1.0; // at distance 0 the conn prob is largest; cosh(0)=1
+    }
+
+    /// upper bound for cosh(dist) to have an edge probability lower than prob
+    /// a vertex pair is surely disconnected if cosh(dist) is larger than the returned value
+    double coshDistForProb_upperBound(double prob) const {
+        assert(prob < max_connection_prob);
+        const auto index = static_cast<int>(stage_width * prob);
+        return filter_stages[index];
+    }
+
+    /// lower bound for cosh(dist) to have an edge probability larger than prob
+    /// a vertex pair is surely connected if cosh(dist) is smaller than the returned value
+    double coshDistForProb_lowerBound(double prob) const {
+        assert(prob < max_connection_prob);
+        const auto index = static_cast<int>(std::ceil(stage_width * prob));
+        return filter_stages[index];
+    }
+
+
+    const double max_connection_prob;     ///< range of the filter. See c'tor
+private:
+
+    /// inverse of the edge probability function
+    /// invConnectionProb(p_uv) = dist_uv
+    double invConnectionProb(double p, double R, double T) const {
+        return R + 2*T*std::log(1.0 / p - 1);
+    }
+
+    std::array<double, stages+1> filter_stages; ///< pos i holds the cosh(distance) at which to points would have a connection prob of (i/stages)
+    const double stage_width;
+};
+
+
+} // namespace hypergirgs

--- a/source/hypergirgs/include/hypergirgs/HyperbolicTree.h
+++ b/source/hypergirgs/include/hypergirgs/HyperbolicTree.h
@@ -7,6 +7,7 @@
 #include <hypergirgs/AngleHelper.h>
 #include <hypergirgs/RadiusLayer.h>
 #include <hypergirgs/Point.h>
+#include <hypergirgs/DistanceFilter.h>
 
 namespace hypergirgs {
 
@@ -49,13 +50,7 @@ protected:
     /// 1.0 / connection probability with respect to hyperbolic distance
     double connectionProbRec(double dist) const;
 
-    /// invConnectionProb(1.0/connectionProbRec(x)) = x
-    double invConnectionProb(double p) const;
-
-    template<size_t kFilterStages>
-    std::pair<std::array<double, kFilterStages>, double> computeFilterStages(double maxProb) const;
-
-    constexpr static size_t kTypeIFilterStages = 8;
+    std::vector<default_random_engine> initialize_prngs(size_t n, unsigned seed) const;
 
 protected:
     EdgeCallback& m_edgeCallback;
@@ -75,9 +70,10 @@ protected:
 
     std::vector<std::vector<std::pair<unsigned int, unsigned int> > > m_layer_pairs;
 
-    std::vector<default_random_engine> initialize_prngs(size_t n, unsigned seed) const;
-
-    std::pair<std::array<double, kTypeIFilterStages>, double> m_typeI_filter;
+    constexpr static size_t filter_size = 100;
+    DistanceFilter<filter_size> m_typeI_filter;
+    /// filter for layer ij on level l is in  m_typeII_filter[i*m_layers+j][l-2]; -2 because level 0 and 1 have no type 2 cell pairs
+    std::vector<std::vector<std::pair<DistanceFilter<filter_size>,DistanceFilter<filter_size>>>> m_typeII_filter;
 
 #ifndef NDEBUG
     long long m_type1_checks{0}; ///< number of node pairs per thread that are checked via a type 1 check

--- a/source/hypergirgs/include/hypergirgs/HyperbolicTree.inl
+++ b/source/hypergirgs/include/hypergirgs/HyperbolicTree.inl
@@ -20,7 +20,7 @@ HyperbolicTree<EdgeCallback>::HyperbolicTree(std::vector<double> &radii, std::ve
     , m_coshR(std::cosh(R))
     , m_T(T)
     , m_R(R)
-    , m_typeI_filter(computeFilterStages<kTypeIFilterStages>(1.0))
+    , m_typeI_filter(1.0, R, T)
 {
     const auto layer_height = 1.0;
 
@@ -36,6 +36,29 @@ HyperbolicTree<EdgeCallback>::HyperbolicTree(std::vector<double> &radii, std::ve
         for (auto i = 0u; i < m_layers; ++i)
             for (auto j = 0u; j < m_layers; ++j)
                 m_layer_pairs[partitioningBaseLevel(m_radius_layers[i].m_r_min, m_radius_layers[j].m_r_min)].emplace_back(i, j);
+    }
+
+    if(m_T) {
+        ScopedTimer timer("Max Connection Prob.", enable_profiling);
+        m_typeII_filter.resize(m_layers*m_layers);
+        for (auto i = 0u; i < m_layers; ++i)
+            for (auto j = 0u; j < m_layers; ++j) {
+                const auto r1 = m_radius_layers[i].m_r_min;
+                const auto r2 = m_radius_layers[j].m_r_min;
+                const auto PBL = partitioningBaseLevel(r1, r2);
+                for(auto l = 2u; l <= PBL; ++l) { // remember that level 0,1 do not contain type2 cell pairs
+                    const auto firstCell = AngleHelper::firstCellOfLevel(l);
+                    // A,A+2 cell pairs
+                    auto angular_distance_lower_bound = AngleHelper::dist(firstCell, firstCell+2, l);
+                    auto dist_lower_bound = hyperbolicDistance(r1, 0, r2, angular_distance_lower_bound);
+                    auto max_connection_prob = 1.0 / connectionProbRec(dist_lower_bound);
+                    // A,A+3 cell pairs
+                    angular_distance_lower_bound = AngleHelper::dist(firstCell, firstCell+3, l);
+                    dist_lower_bound = hyperbolicDistance(r1, 0, r2, angular_distance_lower_bound);
+                    auto max_connection_prob2 = 1.0 / connectionProbRec(dist_lower_bound);
+                    m_typeII_filter[i*m_layers+j].push_back({{max_connection_prob, m_R, m_T}, {max_connection_prob2, m_R, m_T}});
+                }
+            }
     }
 }
 
@@ -127,6 +150,9 @@ void HyperbolicTree<EdgeCallback>::visitCellPair(unsigned int cellA, unsigned in
 
     if(!AngleHelper::touching(cellA, cellB, level))
     {   // not touching cells
+        #ifdef NDEBUG
+        if(!m_T) return; // I dont trust compiler optimization
+        #endif // NDEBUG
         // sample all type 2 occurrences with this cell pair
         for(auto l=level; l<m_levels; ++l)
             for(auto& layer_pair : m_layer_pairs[l])
@@ -293,13 +319,22 @@ void HyperbolicTree<EdgeCallback>::sampleTypeI(unsigned int cellA, unsigned int 
                 }
             } else {
                 const auto rnd = dist(gen);
+                const auto real_dist_cosh = nodeInA.hyperbolicDistanceCosh(nodeInB);
 
-                auto real_dist_cosh = nodeInA.hyperbolicDistanceCosh(nodeInB);
-                if (real_dist_cosh > m_typeI_filter.first[static_cast<int>(m_typeI_filter.second * rnd)]) {
+                // check if we wouldn't make it even if rnd was a little smaller
+                if (real_dist_cosh > m_typeI_filter.coshDistForProb_upperBound(rnd)) {
                     assert(rnd * connectionProbRec(std::acosh(real_dist_cosh)) >= 1.0);
                     continue;
                 }
 
+                // check if we would make it even if rnd was a little higher
+                if (real_dist_cosh < m_typeI_filter.coshDistForProb_lowerBound(rnd)) {
+                    assert(rnd * connectionProbRec(std::acosh(real_dist_cosh)) < 1.0);
+                    m_edgeCallback(nodeInA.id, nodeInB.id, threadId);
+                    continue;
+                }
+
+                // rnd is very close to the prob at which we connect this pair
                 if(rnd * connectionProbRec(std::acosh(real_dist_cosh)) < 1.0) {
                     m_edgeCallback(nodeInA.id, nodeInB.id, threadId);
                 }
@@ -314,35 +349,44 @@ void HyperbolicTree<EdgeCallback>::sampleTypeII(unsigned int cellA, unsigned int
     // TODO use cell iterators
     const auto sizeV_i_A = static_cast<long long>(m_radius_layers[i].pointsInCell(cellA, level));
     const auto sizeV_j_B = static_cast<long long>(m_radius_layers[j].pointsInCell(cellB, level));
-    if (m_T == 0 || sizeV_i_A == 0 || sizeV_j_B == 0) {
+
 #ifndef NDEBUG
-        #pragma omp atomic
-        m_type2_checks += 2ll * sizeV_i_A * sizeV_j_B;
+    #pragma omp atomic
+    m_type2_checks += 2ll * sizeV_i_A * sizeV_j_B;
 #endif // NDEBUG
+
+    if (m_T == 0 || sizeV_i_A == 0 || sizeV_j_B == 0)
         return;
+
+    const auto& filters = m_typeII_filter[i*m_layers+j][level-2];
+    assert(AngleHelper::cellsBetween(cellA, cellB, level) == 1 || AngleHelper::cellsBetween(cellA, cellB, level) == 2);
+    const auto& filter = (AngleHelper::cellsBetween(cellA, cellB, level) == 1 ? filters.first : filters.second);
+    const auto max_connection_prob = filter.max_connection_prob;
+
+    // skipping over points is actually quite expensive as it messes up
+    // branch predictions and prefetching. Hence low expected skip distances
+    // it's cheapter to throw a coin each time!
+    if (max_connection_prob > 0.2) {
+        #ifndef NDEBUG
+            #pragma omp atomic
+            m_type2_checks -= 2ll * sizeV_i_A * sizeV_j_B;
+        #endif // NDEBUG
+        return sampleTypeI(cellA, cellB, level, i, j, gen);
     }
 
+#ifndef NDEBUG
     // get upper bound for probability
     auto r_boundA = m_radius_layers[i].m_r_min;
     auto r_boundB = m_radius_layers[j].m_r_min;
     auto angular_distance_lower_bound = AngleHelper::dist(cellA, cellB, level);
     auto dist_lower_bound = hyperbolicDistance(r_boundA, 0, r_boundB, angular_distance_lower_bound);
-    auto max_connection_prob = 1.0 / connectionProbRec(dist_lower_bound);
+    auto max_connection_prob_check = 1.0 / connectionProbRec(dist_lower_bound);
+    assert(max_connection_prob == max_connection_prob_check);
+#endif // NDEBUG
 
-    // if we must sample all pairs we treat this as type 1 sampling
-    // also, 1.0 is no valid prob for a geometric dist (see c++ std)
-    if(max_connection_prob == 1.0){
-        sampleTypeI(cellA, cellB, level, i, j, gen);
-        return;
-    }
 
     const auto num_pairs = sizeV_i_A * sizeV_j_B;
     const auto expected_samples = num_pairs * max_connection_prob;
-
-#ifndef NDEBUG
-    #pragma omp atomic
-    m_type2_checks += 2llu * num_pairs;
-#endif // NDEBUG
 
     if(expected_samples < 1e-6)
         return;
@@ -352,66 +396,47 @@ void HyperbolicTree<EdgeCallback>::sampleTypeII(unsigned int cellA, unsigned int
     auto geo = std::geometric_distribution<unsigned long long>(max_connection_prob);
     std::uniform_real_distribution<> dist(0.0, max_connection_prob);
 
-    if (expected_samples > 10.) {
-        const auto filters = computeFilterStages<3>(max_connection_prob);
+    const auto* pointsA = &m_radius_layers[i].kthPoint(cellA, level, 0);
+    const auto* pointsB = &m_radius_layers[j].kthPoint(cellB, level, 0);
 
-        for (auto r = geo(gen); r < num_pairs; r += 1 + geo(gen)) {
-            // determine the r-th pair
-            const auto& nodeInA = m_radius_layers[i].kthPoint(cellA, level, r%sizeV_i_A);
-            const auto& nodeInB = m_radius_layers[j].kthPoint(cellB, level, r/sizeV_i_A);
+    for (auto r = geo(gen); r < num_pairs; r += 1 + geo(gen)) {
+        // determine the r-th pair
+        const auto& nodeInA = pointsA[r%sizeV_i_A];
+        const auto& nodeInB = pointsB[r/sizeV_i_A];
 
-            // points are in correct cells
-            assert(cellA - AngleHelper::firstCellOfLevel(level) == AngleHelper::cellForPoint(nodeInA.angle, level));
-            assert(cellB - AngleHelper::firstCellOfLevel(level) == AngleHelper::cellForPoint(nodeInB.angle, level));
+        // points are in correct cells
+        assert(cellA - AngleHelper::firstCellOfLevel(level) == AngleHelper::cellForPoint(nodeInA.angle, level));
+        assert(cellB - AngleHelper::firstCellOfLevel(level) == AngleHelper::cellForPoint(nodeInB.angle, level));
 
-            // points are in correct radius layer
-            assert(m_radius_layers[i].m_r_min < nodeInA.radius && nodeInA.radius <= m_radius_layers[i].m_r_max);
-            assert(m_radius_layers[j].m_r_min < nodeInB.radius && nodeInB.radius <= m_radius_layers[j].m_r_max);
+        // points are in correct radius layer
+        assert(m_radius_layers[i].m_r_min < nodeInA.radius && nodeInA.radius <= m_radius_layers[i].m_r_max);
+        assert(m_radius_layers[j].m_r_min < nodeInB.radius && nodeInB.radius <= m_radius_layers[j].m_r_max);
 
-            // get actual connection probability
-            const auto real_dist_cosh = nodeInA.hyperbolicDistanceCosh(nodeInB);
-            assert(angular_distance_lower_bound <= std::abs(nodeInA.angle - nodeInB.angle));
-            assert(angular_distance_lower_bound <= std::abs(nodeInB.angle - nodeInA.angle));
-            assert(std::acosh(real_dist_cosh) >= dist_lower_bound);
-            assert(std::acosh(real_dist_cosh) > m_R);
+        // get actual connection probability
+        const auto real_dist_cosh = nodeInA.hyperbolicDistanceCosh(nodeInB);
+        assert(angular_distance_lower_bound <= std::abs(nodeInA.angle - nodeInB.angle));
+        assert(angular_distance_lower_bound <= std::abs(nodeInB.angle - nodeInA.angle));
+        assert(std::acosh(real_dist_cosh) >= dist_lower_bound);
+        assert(std::acosh(real_dist_cosh) > m_R);
 
-            const auto rnd = dist(gen);
-            if (real_dist_cosh > filters.first[static_cast<int>(filters.second * rnd)]) {
-                assert(rnd * connectionProbRec(std::acosh(real_dist_cosh)) >= 1.0);
-                continue;
-            }
+        const auto rnd = dist(gen);
 
-            auto connection_prob = connectionProbRec(std::acosh(real_dist_cosh));
-            if(rnd * connection_prob < 1.0) {
-                m_edgeCallback(nodeInA.id, nodeInB.id, threadId);
-            }
+        // check if we wouldn't make it even if rnd was a little smaller
+        if (real_dist_cosh > filter.coshDistForProb_upperBound(rnd)) {
+            assert(rnd * connectionProbRec(std::acosh(real_dist_cosh)) >= 1.0);
+            continue;
         }
 
-    } else {
-        for (auto r = geo(gen); r < num_pairs; r += 1 + geo(gen)) {
-            // determine the r-th pair
-            const auto& nodeInA = m_radius_layers[i].kthPoint(cellA, level, r%sizeV_i_A);
-            const auto& nodeInB = m_radius_layers[j].kthPoint(cellB, level, r/sizeV_i_A);
+        // check if we would make it even if rnd was a little higher
+        if (real_dist_cosh < filter.coshDistForProb_lowerBound(rnd)) {
+            assert(rnd * connectionProbRec(std::acosh(real_dist_cosh)) < 1.0);
+            m_edgeCallback(nodeInA.id, nodeInB.id, threadId);
+            continue;
+        }
 
-            // points are in correct cells
-            assert(cellA - AngleHelper::firstCellOfLevel(level) == AngleHelper::cellForPoint(nodeInA.angle, level));
-            assert(cellB - AngleHelper::firstCellOfLevel(level) == AngleHelper::cellForPoint(nodeInB.angle, level));
-
-            // points are in correct radius layer
-            assert(m_radius_layers[i].m_r_min < nodeInA.radius && nodeInA.radius <= m_radius_layers[i].m_r_max);
-            assert(m_radius_layers[j].m_r_min < nodeInB.radius && nodeInB.radius <= m_radius_layers[j].m_r_max);
-
-            // get actual connection probability
-            const auto real_dist = nodeInA.hyperbolicDistance(nodeInB);
-            assert(angular_distance_lower_bound <= std::abs(nodeInA.angle - nodeInB.angle));
-            assert(angular_distance_lower_bound <= std::abs(nodeInB.angle - nodeInA.angle));
-            assert(real_dist >= dist_lower_bound);
-            assert(real_dist > m_R);
-
-            const auto connection_prob = connectionProbRec(real_dist);
-            if(dist(gen) * connection_prob < 1.0) {
-                m_edgeCallback(nodeInA.id, nodeInB.id, threadId);
-            }
+        // rnd is very close to the prob at which we connect this pair
+        if(rnd * connectionProbRec(std::acosh(real_dist_cosh)) < 1.0) {
+            m_edgeCallback(nodeInA.id, nodeInB.id, threadId);
         }
     }
 }
@@ -452,21 +477,6 @@ unsigned int HyperbolicTree<EdgeCallback>::partitioningBaseLevel(double r1, doub
 template<typename EdgeCallback>
 double HyperbolicTree<EdgeCallback>::connectionProbRec(double dist) const {
     return 1.0 + std::exp(0.5/m_T*(dist-m_R));
-}
-
-template<typename EdgeCallback>
-double HyperbolicTree<EdgeCallback>::invConnectionProb(double p) const {
-    return m_R + 2*m_T*std::log(1.0 / p - 1);
-}
-
-template<typename EdgeCallback>
-template<size_t kFilterStages>
-std::pair<std::array<double, kFilterStages>, double> HyperbolicTree<EdgeCallback>::computeFilterStages(double max_connection_prob) const {
-    std::array<double, kFilterStages> filters;
-    for(int i=0; i < kFilterStages; i++)
-        filters[i] = cosh(invConnectionProb(max_connection_prob / kFilterStages * i));
-    const double filter_width = kFilterStages / max_connection_prob;
-    return {filters, filter_width};
 }
 
 

--- a/source/hypergirgs/source/AngleHelper.cpp
+++ b/source/hypergirgs/source/AngleHelper.cpp
@@ -21,10 +21,14 @@ bool AngleHelper::touching(unsigned int cellA, unsigned int cellB, unsigned int 
 }
 
 double AngleHelper::dist(unsigned int cellA, unsigned int cellB, unsigned int level) {
+    return cellsBetween(cellA, cellB, level) * 2.0*PI / (1<<level); // last terms are cell width
+}
+
+int AngleHelper::cellsBetween(unsigned int cellA, unsigned int cellB, unsigned int level) {
     auto mm = std::minmax(cellA,cellB);
     auto diff = mm.second - mm.first;
     diff = std::min(diff, numCellsInLevel(level) - diff);
-    return (diff <= 1) ? 0 : (diff-1) * 2.0*PI / (1<<level);
+    return (diff <= 1) ? 0 : diff-1;
 }
 
 


### PR DESCRIPTION
Depending on the parameters approx 50% of total work is spent computing `exp` and `log`. This PR reduces this number for T>0 based on the following idea:

Rather than evaluation hyperbolicDistance (includes `acosh` ->`log`) and then computing connectionProbability (invokes `exp`), we precompute cosh(maximal distance) a point pair is allowed to have, given the randomly drawn uniform variate.
We do this for a few intervals the random variate might have (experimentally 3 seems a good choice) and only compute theses values if we expect to sample more than 10 points in `sampleTypeII`.

Also, I removed the division from the connectionProbability function, since in almost all cases, we can rewrite the checks where its used to work with 1/connProb.

I do realize that this PR increases the code by copying `sampleTypeII`, but it brings a speed-up of 10% - ~25%. 
