### PR TITLE
Add nix flake to allow for easy setup and reproducable builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ _start-cmd.bat
 
 # Wiki
 wiki
+
+# nix output
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1739020877,
+        "narHash": "sha256-mIvECo/NNdJJ/bXjNqIh8yeoSjVLAuDuTUzAo7dzs8Y=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a79cfe0ebd24952b580b1cf08cd906354996d547",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,91 @@
+{
+  description = "Generator for Geometric Inhomogeneous Random Graphs";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        packages.default = pkgs.stdenv.mkDerivation {
+          pname = "girgs";
+          version = "1.0.2";
+
+          src = ./.;
+
+          nativeBuildInputs = with pkgs; [
+            cmake
+            ninja
+          ];
+
+          buildInputs = with pkgs; [
+            boost
+            gtest
+            doxygen
+            graphviz
+          ];
+
+          cmakeFlags = [
+            "-DCMAKE_BUILD_TYPE=Release"
+            "-DOPTION_BUILD_TESTS=ON"
+            "-DOPTION_BUILD_EXAMPLES=ON"
+            "-DOPTION_BUILD_CLI=ON"
+          ];
+
+          meta = with pkgs.lib; {
+            description = "Generator for Geometric Inhomogeneous Random Graphs";
+            homepage = "https://github.com/chistopher/girgs";
+            license = {
+              fullName = "MIT License";
+              url = "https://opensource.org/licenses/MIT";
+              spdxId = "MIT";
+              file = ./LICENSE;
+            };
+            platforms = platforms.unix;
+            maintainers = with maintainers; [ 
+              (maintainers.lib.maintainer {
+                name = "Dennis Kobert";
+                email = "dennis@kobert.dev";
+                github = "TrueDoctor";
+              })
+            ];
+          };
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            cmake
+            ninja
+            boost
+            gtest
+            doxygen
+            graphviz
+            gcc
+            gdb
+            valgrind
+            ccache
+            clang-tools # For clang-format, clang-tidy
+            pre-commit
+          ];
+
+          # Set environment variables for development
+          shellHook = ''
+            echo "Welcome to GIRGS development environment!"
+            echo "Build tools and dependencies are available."
+            
+            # Setup ccache
+            export CCACHE_DIR=$PWD/.ccache
+            export PATH="${pkgs.ccache}/bin:$PATH"
+            
+            # Make tests verbose by default
+            export CTEST_OUTPUT_ON_FAILURE=1
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
Nix flakes are used by the nix package manager to declaratively build packages, modeling the build tools as dependencies. When entering the development shell, all dependencies use the same version as was used for development, I'd imagine that to be useful for research code. This pull request adds a `flake.nix` (which describes the package) and a `flake.lock` which pins the dependency versions. 